### PR TITLE
Fixed the link to the Code of Conduct

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -25,7 +25,7 @@ function Footer() {
       <div className="flex flex-col lg:flex-row">
         {[
           {
-            route: "https://git.io/Jemzv",
+            route: "https://docs.oscafrica.org/about/community-code-of-conduct#osca-events",
             title: "Code of Conduct"
           },
           {


### PR DESCRIPTION
The link was broken due to the migration to the docs.oscafrica.org